### PR TITLE
feat(AppProvider): AppProviders can stop listening

### DIFF
--- a/src/express/ExpressProvider.ts
+++ b/src/express/ExpressProvider.ts
@@ -1,3 +1,4 @@
+import http from 'http';
 import express, { Express, NextFunction, Request, RequestHandler, Response } from 'express';
 import { checkScope, checkToken, checkUseCase } from './SecurityHandler';
 import { choose } from '../utils';
@@ -31,6 +32,9 @@ const toResponse = (res: Response, result?: unknown, options?: VerbOptions) => {
 };
 
 export class ExpressProvider implements AppProvider {
+  private _server: http.Server;
+  public get server(): http.Server { return this._server; }
+
   constructor(private app: Express = express()) {
     this.app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
   }
@@ -63,10 +67,14 @@ export class ExpressProvider implements AppProvider {
   };
 
   listen = (port: number, message = `Service is listening on port ${port}.`): void => {
-    this.app.listen(port, () => {
+    this._server = this.app.listen(port, () => {
       console.log(message);
     });
   };
+
+  stop = (): void => {
+    this._server.close();
+  }
 }
 
 export const service = (name: string): Service => new Service(name, new ExpressProvider());

--- a/src/resources/AppProvider.ts
+++ b/src/resources/AppProvider.ts
@@ -7,4 +7,5 @@ export interface AppProvider {
   use: (h: Handler) => void;
   route: (s: Service, r: Resource) => void;
   listen: (port: number, message?: string) => void;
+  stop: () => void;
 }

--- a/test/express/ExpressProvider.test.ts
+++ b/test/express/ExpressProvider.test.ts
@@ -8,7 +8,8 @@ type AsyncHandler = (req: Request, res: Response, next: NextFunction) => Promise
 type Endpoint = { path?: string; handler?: AsyncHandler };
 
 describe('ExpressProvider', () => {
-  const app = ({ listen: mock.return(), use: mock.return(), set: mock.return() } as unknown) as Express;
+  const server = ({close: mock.return()});
+  const app = ({listen: mock.return(server), use: mock.return(), set: mock.return(), close: mock.return() } as unknown) as Express;
   const handler: Handler = () => undefined;
   let provider: ExpressProvider;
   let service: DevService;
@@ -103,4 +104,10 @@ describe('ExpressProvider', () => {
     expect(res.status).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledWith(fits.with({ origin: Exception.DoesNotExist }));
   });
+
+  test('Stop listening', () => {
+    provider.listen(9001);
+    provider.stop();
+    expect(provider.server.close).toHaveBeenCalled();
+  })
 });

--- a/test/resources/Service.test.ts
+++ b/test/resources/Service.test.ts
@@ -6,7 +6,7 @@ describe('Service', () => {
   let app: AppProvider;
 
   beforeEach(() => {
-    app = { use: mock.return(), route: mock.return(), listen: mock.return() };
+    app = { use: mock.return(), route: mock.return(), listen: mock.return(), stop: mock.return() };
   });
 
   test('Construction works', () => {


### PR DESCRIPTION
Added functionalitie to stop the AppProvider from listening, so that I can stop a service programmatically.