### PR TITLE
- fix: Struct.update should not have an optional param

### DIFF
--- a/src/domain/Struct.ts
+++ b/src/domain/Struct.ts
@@ -16,7 +16,7 @@ export abstract class Struct implements Validatable {
     return this.constructor.name;
   }
 
-  update = (add: Json): Struct => this;
+  update = (_add: Json): Struct => this;
 
   protected merge = (a: Json): Json => json.merge(this, a);
 }

--- a/src/domain/Struct.ts
+++ b/src/domain/Struct.ts
@@ -16,7 +16,7 @@ export abstract class Struct implements Validatable {
     return this.constructor.name;
   }
 
-  update = (add?: Json): Struct => this;
+  update = (add: Json): Struct => this;
 
   protected merge = (a: Json): Json => json.merge(this, a);
 }


### PR DESCRIPTION
In my  opinion `Struct.update` should not have an optional parameter.
This leads to unnecessary complex code in sub-classes:

`update = (add?: Json): Dev => add ? new Dev(this.merge(add)) : this;`