### PR TITLE
feat(test-react): Support mouseDown event

### DIFF
--- a/packages/easy-test-react/src/ElementTester.ts
+++ b/packages/easy-test-react/src/ElementTester.ts
@@ -20,9 +20,9 @@ export class ElementTester {
     return new Tester(this.element() as HTMLElement);
   }
 
-  click = (): this | undefined => (this.element() && fireEvent.click(this.element())) ? this : undefined;
+  click = (): this | undefined => (this.element() && fireEvent.click(this.element()) ? this : undefined);
+  mouseDown = (): this | undefined => (this.element() && fireEvent.mouseDown(this.element()) ? this : undefined);
   type = (value: string): boolean => fireEvent.change(this.element(), { target: { value } });
   wait = (): Promise<Element> => waitFor(this.element);
   waitForRemove = (): Promise<void> => waitForElementToBeRemoved(this.element);
 }
-

--- a/packages/easy-test-react/test/ElementTester.test.tsx
+++ b/packages/easy-test-react/test/ElementTester.test.tsx
@@ -47,6 +47,20 @@ describe('ElementTester', () => {
     expect(fireEvent.click).toHaveBeenCalledWith(a);
   });
 
+  test('mouseDown fires mousedown event', () => {
+    fireEvent.mouseDown = mock.return(true);
+    expect(et.mouseDown()).toBe(et);
+    expect(getByText).toHaveBeenCalled();
+    expect(fireEvent.mouseDown).toHaveBeenCalledWith(a);
+  });
+
+  test('mouseDown fires mouseDown event but fails', () => {
+    fireEvent.mouseDown = mock.return(false);
+    expect(et.mouseDown()).not.toBeValid();
+    expect(getByText).toHaveBeenCalled();
+    expect(fireEvent.mouseDown).toHaveBeenCalledWith(a);
+  });
+
   test('type fires value change event', () => {
     fireEvent.change = mock.return();
     const value = 'hello';


### PR DESCRIPTION
Useful for testing libraries like rc-select where mouseDown is required