### PR TITLE
feat(easy): add a generic retry functionality for promises

### DIFF
--- a/packages/easy/src/utils/Retry.ts
+++ b/packages/easy/src/utils/Retry.ts
@@ -1,0 +1,30 @@
+import { ErrorOrigin, Exception, when } from '@thisisagile/easy';
+
+export class Wait {
+  static wait(ms = 0): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  static seconds(s = 0) {
+    return this.wait(s * 1000);
+  }
+}
+
+export const wait = (millis: number) => Wait.wait(millis);
+
+export class Retry<T = any> {
+  constructor(readonly subject: () => Promise<T>, readonly times = 3, readonly interval = 1000, readonly prevError?: ErrorOrigin) {}
+
+  run = (): Promise<T> =>
+    when(this.times)
+      .not.isTrue.reject(this.prevError ?? Exception.CouldNotExecute)
+      .then(() =>
+        this.subject().catch(async e => {
+          await wait(this.interval);
+          return retry(this.subject, this.times - 1, this.interval, e);
+        })
+      );
+}
+
+export const retry = <T>(subject: () => Promise<T>, times?: number, interval?: number, prevError?: ErrorOrigin): Promise<T> =>
+  new Retry<T>(subject, times, interval, prevError).run();

--- a/packages/easy/src/utils/index.ts
+++ b/packages/easy/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './Log';
 export * from './Mapper';
 export * from './Promise';
 export * from './Property';
+export * from './Retry';
 export * from './State';
 export * from './Sentence';
 export * from './Traverse';

--- a/packages/easy/test/utils/Retry.test.ts
+++ b/packages/easy/test/utils/Retry.test.ts
@@ -1,0 +1,72 @@
+import { mock } from '@thisisagile/easy-test';
+import { wait, Wait, retry, Retry } from '../../src';
+
+jest.useFakeTimers();
+jest.spyOn(global, 'setTimeout');
+
+describe('Wait', () => {
+  test('wait call milli', () => {
+    void wait(300);
+    jest.advanceTimersByTime(300);
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 300);
+    jest.runAllTimers();
+  });
+
+  test('wait call second', () => {
+    void Wait.seconds(2);
+    jest.advanceTimersByTime(2000);
+    expect(setTimeout).toHaveBeenCalledTimes(2);
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 2000);
+    jest.runAllTimers();
+  });
+});
+
+describe('Retry', () => {
+  beforeEach(() => {
+    Wait.wait = mock.resolve();
+  });
+
+  test('resolves', async () => {
+    const cb = mock.resolve('fulfilled');
+    const r = retry(cb);
+    await expect(r).resolves.toBe('fulfilled');
+  });
+
+  test('normal retry', async () => {
+    const cb = jest.fn().mockRejectedValueOnce(new Error('rejected')).mockResolvedValueOnce('fulfilled');
+    const r = retry(cb, 3, 100);
+    await expect(r).resolves.toBe('fulfilled');
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(Wait.wait).toHaveBeenCalledTimes(1);
+  });
+
+  test('retry with two fails', async () => {
+    const cb = jest.fn().mockRejectedValueOnce(new Error('rejected')).mockRejectedValueOnce(new Error('rejected')).mockResolvedValueOnce('fulfilled');
+
+    await expect(retry(cb)).resolves.toBe('fulfilled');
+    expect(cb).toHaveBeenCalledTimes(3);
+    expect(Wait.wait).toHaveBeenCalledTimes(2);
+  });
+
+  test('retry 2 times with two fails', async () => {
+    const cb = jest.fn().mockRejectedValueOnce(new Error('rejected')).mockRejectedValueOnce(new Error('rejected')).mockResolvedValueOnce('fulfilled');
+
+    await expect(retry(cb, 2)).rejects.toThrow(new Error('rejected'));
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(Wait.wait).toHaveBeenCalledTimes(2);
+  });
+
+  test('exceed max retry', async () => {
+    const cb = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('rejected 1'))
+      .mockRejectedValueOnce(new Error('rejected 2'))
+      .mockRejectedValueOnce(new Error('rejected 3'))
+      .mockRejectedValueOnce(new Error('rejected 4'));
+
+    await expect(retry(cb, 3)).rejects.toThrow(new Error('rejected 3'));
+    expect(cb).toHaveBeenCalledTimes(3);
+    expect(Wait.wait).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
Add wait and retry to easy