### PR TITLE
feat(test-react): use screen instead of contianer for Tester queries

### DIFF
--- a/packages/easy-test-react/src/Tester.ts
+++ b/packages/easy-test-react/src/Tester.ts
@@ -1,4 +1,4 @@
-import { getByPlaceholderText, getByRole, getByTestId, getByText, getByTitle, render } from '@testing-library/react';
+import { getByPlaceholderText, getByRole, getByTestId, getByText, getByTitle, render, screen } from '@testing-library/react';
 import { ReactElement } from 'react';
 import { Id } from '@thisisagile/easy';
 import { waitForRender } from './waitForRender';
@@ -10,15 +10,15 @@ export class Tester {
   static render = (component: ReactElement): Promise<Tester> => waitForRender(component).then(c => new Tester(c.container));
   static renderSync = (component: ReactElement): Tester => new Tester(render(component).container);
 
-  byText = (text: string): HTMLElement => getByText(this.container, text);
+  byText = (text: string): HTMLElement => screen.getByText(text);
   atText = (text: string): ElementTester => new ElementTester(() => this.byText(text));
-  byId = (id: Id): HTMLElement => getByTestId(this.container, id.toString());
+  byId = (id: Id): HTMLElement => screen.getByTestId(id.toString());
   atId = (id: Id): ElementTester => new ElementTester(() => this.byId(id));
-  byRole = (role: string): HTMLElement => getByRole(this.container, role);
+  byRole = (role: string): HTMLElement => screen.getByRole(role);
   atRole = (role: string): ElementTester => new ElementTester(() => this.byRole(role));
-  byTitle = (title: string): HTMLElement => getByTitle(this.container, title);
+  byTitle = (title: string): HTMLElement => screen.getByTitle(title);
   atTitle = (title: string): ElementTester => new ElementTester(() => this.byTitle(title));
-  byPlaceholder = (placeholder: string): HTMLElement => getByPlaceholderText(this.container, placeholder);
+  byPlaceholder = (placeholder: string): HTMLElement => screen.getByPlaceholderText( placeholder);
   atPlaceholder = (placeholder: string): ElementTester => new ElementTester(() => this.byPlaceholder(placeholder));
   submit = (id: Id = 'btn-submit'): ElementTester => this.atId(id);
 }

--- a/packages/easy-test-react/test/ElementTester.test.tsx
+++ b/packages/easy-test-react/test/ElementTester.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mock } from '@thisisagile/easy-test';
 
 const getByText = mock.return(<div />);
-jest.mock('@testing-library/react', () => ({ ...jest.requireActual('@testing-library/react'), getByText }));
+jest.mock('@testing-library/react', () => ({ ...jest.requireActual('@testing-library/react'), screen: {getByText} }));
 import { fireEvent } from '@testing-library/react';
 import { ElementTester, Tester, renders } from '../src';
 

--- a/packages/easy-test-react/test/Tester.test.tsx
+++ b/packages/easy-test-react/test/Tester.test.tsx
@@ -10,11 +10,13 @@ const getByPlaceholderText = mock.return(<div />);
 jest.mock('@testing-library/react', () => ({
   ...jest.requireActual('@testing-library/react'),
   render,
-  getByText,
-  getByTestId,
-  getByTitle,
-  getByRole,
-  getByPlaceholderText,
+  screen: {
+    getByText,
+    getByTestId,
+    getByTitle,
+    getByRole,
+    getByPlaceholderText,
+  }
 }));
 import { ElementTester, renders, Tester } from '../src';
 
@@ -30,35 +32,35 @@ describe('Tester', () => {
     const t = renders(a);
     t.byText('');
     expect(render).toHaveBeenCalledWith(a);
-    expect(getByText).toHaveBeenCalledWith(a, '');
+    expect(getByText).toHaveBeenCalledWith('');
   });
 
   test('byId calls screen.getByTestId', () => {
     const t = renders(a);
     t.byId('');
     expect(render).toHaveBeenCalledWith(a);
-    expect(getByTestId).toHaveBeenCalledWith(a, '');
+    expect(getByTestId).toHaveBeenCalledWith('');
   });
 
   test('byTitle calls screen.getByTitle', () => {
     const t = renders(a);
     t.byTitle('');
     expect(render).toHaveBeenCalledWith(a);
-    expect(getByTitle).toHaveBeenCalledWith(a, '');
+    expect(getByTitle).toHaveBeenCalledWith('');
   });
 
   test('byRole calls screen.getByTestId', () => {
     const t = renders(a);
     t.byRole('');
     expect(render).toHaveBeenCalledWith(a);
-    expect(getByRole).toHaveBeenCalledWith(a, '');
+    expect(getByRole).toHaveBeenCalledWith('');
   });
 
   test('byPlaceholder calls screen.getByTestId', () => {
     const t = renders(a);
     t.byPlaceholder('');
     expect(render).toHaveBeenCalledWith(a);
-    expect(getByPlaceholderText).toHaveBeenCalledWith(a, '');
+    expect(getByPlaceholderText).toHaveBeenCalledWith('');
   });
 
   test('at returns ElementTester', () => {


### PR DESCRIPTION
I made use of a screen instead of a container for querying for Tester to query elements render outside of the container. 