### PR TITLE
Fix Country.byId performance

### DIFF
--- a/packages/easy/src/domain/enums/Country.ts
+++ b/packages/easy/src/domain/enums/Country.ts
@@ -1,4 +1,4 @@
-import { Enum, Id, text } from '../../types';
+import {Enum, Get, Id, ofGet, text} from '../../types';
 
 export class Country extends Enum {
   static readonly AF = new Country('Afghanistan', 'AF');
@@ -253,6 +253,10 @@ export class Country extends Enum {
 
   constructor(name: string, id: string, private readonly lower = text(id).lower.trim.toString()) {
     super(name, id);
+  }
+
+  static byId<E extends Enum>(id: Id, alt?: Get<E, unknown>): E {
+    return (Country[`${id}`.toUpperCase() as keyof typeof Country] as Enum ?? this.first(e => e.equals(id)) ?? ofGet(alt)) as E;
   }
 
   equals<E extends Enum>(other: E | Id): other is E {

--- a/packages/easy/test/domain/enums/Country.test.ts
+++ b/packages/easy/test/domain/enums/Country.test.ts
@@ -17,6 +17,14 @@ describe('Country', () => {
     expect(Country.byId('NL')).toBe(Country.NL);
   });
 
+  test('byId is fast.', ()=>{
+    jest.spyOn(Country, 'first');
+    expect(Country.byId('nl')).toBe(Country.NL);
+    expect(Country.first).toHaveBeenCalledTimes(0);
+    expect(Country.byId('xx')).toBeUndefined();
+    expect(Country.first).toHaveBeenCalledTimes(1);
+  });
+
   test('byIds.', () => {
     expect(Country.byIds<Country>(['nl'])).toMatchText(toList<Country>(Country.NL));
   });

--- a/packages/easy/test/domain/values/DateTime.test.ts
+++ b/packages/easy/test/domain/values/DateTime.test.ts
@@ -305,7 +305,7 @@ describe('DateTime', () => {
     const dt = new DateTime(iso);
     expect(dt.toLocale()).toMatchText('25-3-2021');
     expect(dt.toLocale('de-DE')).toMatchText('25.3.2021');
-    expect(dt.toLocale('de-DE', 'ffff')).toMatchText('Donnerstag, 25. März 2021, 08:39 UTC');
+    expect(dt.toLocale('de-DE', 'ffff')).toMatchText('Donnerstag, 25. März 2021 um 08:39 UTC');
   });
 
   test('toFull', () => {
@@ -333,7 +333,7 @@ describe('DateTime', () => {
     const d = new DateTime(iso).withZone('America/New_York');
     expect(d).toMatchText(new_york);
     expect(d.toJSON()).toMatchText(iso);
-    expect(d.toLocale('en-US', 'ffff')).toMatchText('Thursday, March 25, 2021, 4:39 AM GMT-04:00');
+    expect(d.toLocale('en-US', 'ffff')).toMatchText('Thursday, March 25, 2021 at 4:39 AM GMT-04:00');
   });
 
   test('toString keeps zone', () => {


### PR DESCRIPTION
The lookup of a Country byId is pretty slow when having to do repeated lookups. This PR adds direct lookup by key which greatly boosts performance.

Testcase:
```
const start = Date.now();
for (let i = 0; i < 100000; i++) {
  Country.byId('nl');
}
console.debug('Country.byId took', Date.now() - start, 'ms');
```
before: Country.byId took 16413 ms
after: Country.byId took 8 ms