### PR TITLE
fix(easy-react): Fix useToggle to change value when different props a…

### DIFF
--- a/packages/easy-react/src/utils/Hooks.ts
+++ b/packages/easy-react/src/utils/Hooks.ts
@@ -1,9 +1,13 @@
 import { isPageList, List, Optional, PageList, PageOptions, toList, toPageList, Validatable } from '@thisisagile/easy';
-import { useState } from 'react';
+import {useCallback, useEffect, useState} from 'react';
 
 export const useToggle = (initialState = false): [boolean, () => void] => {
   const [state, setState] = useState<boolean>(initialState);
-  return [state, () => setState(s => !s)];
+  const toggle = useCallback(() => setState(s => !s), []);
+  useEffect(() => {
+    setState(initialState)
+  }, [initialState])
+  return [state, toggle];
 };
 
 export const useA = <E extends Validatable>(item: Partial<E> = {} as Partial<E>): [E, (e: E) => E] => {


### PR DESCRIPTION
This fix is for mutating the state when a new initialState bool is passed.  This is needed for components that use useToggle and they want to support a controlled/uncontrolled flow.