### PR TITLE
fix: Refactor URL method in PuppeteerTester class

### DIFF
--- a/packages/easy-puppeteer/src/PuppeteerTester.ts
+++ b/packages/easy-puppeteer/src/PuppeteerTester.ts
@@ -7,7 +7,7 @@ export class PuppeteerTester implements Tester {
   constructor(public host: string, private readonly browser: Browser, private readonly page: Page) {}
 
   get url(): string {
-    return this.page.target().url();
+    return this.page.url();
   }
 
   /* istanbul ignore next */

--- a/packages/easy-puppeteer/test/PuppeteerTester.test.ts
+++ b/packages/easy-puppeteer/test/PuppeteerTester.test.ts
@@ -1,5 +1,5 @@
 import { mock } from '@thisisagile/easy-test';
-import { Browser, ElementHandle, HTTPResponse, Page, Target } from 'puppeteer';
+import { Browser, ElementHandle, HTTPResponse, Page } from 'puppeteer';
 import { PuppeteerElement, PuppeteerTester } from '../src';
 import { DevUseCase } from '@thisisagile/easy/test/ref/DevUseCase';
 
@@ -215,9 +215,7 @@ describe('PuppeteerTester', () => {
   });
 
   test('url', () => {
-    page.target = mock.return(mock.empty<Target>());
-    page.target().url = mock.return('http://thisurl.com');
-
+    page.url = mock.return('http://thisurl.com');
     expect(tester.url).toMatch('http://thisurl.com');
   });
 


### PR DESCRIPTION
The change switches the URL method in the PuppeteerTester class to directly access the page's URL, simplifying the code and improving readability. This change is reflected in the associated test by altering how the page's URL is mocked.

<img width="522" alt="image" src="https://github.com/thisisagile/easy/assets/8200242/44ce3917-a3d1-40b7-acae-8893a02a2059">
