### PR TITLE
feat: Add List import and resolve method in Promise.test.ts and Promi…

### DIFF
--- a/packages/easy/src/utils/Promise.ts
+++ b/packages/easy/src/utils/Promise.ts
@@ -1,4 +1,4 @@
-import { ErrorOrigin, toArray } from '../types';
+import { ErrorOrigin, List, toArray, toList } from '../types';
 
 type Pro<A> = A | PromiseLike<A>;
 type Aw<A> = Awaited<A>;
@@ -15,6 +15,7 @@ export const tuple = {
     Promise.all([first, second, third, forth, fifth]),
   all: <F, S>(first: Pro<F>, second: Pro<S>[]): Promise<[Aw<F>, Aw<S[]>]> => Promise.all([first, Promise.all(second)]),
   spread: <F, S>(first: Pro<F>, ...second: Pro<S>[]): Promise<[Aw<F>, Aw<S[]>]> => Promise.all([first, Promise.all(toArray(second))]),
+  list: <T>(list: Pro<T>[]): Promise<List<Aw<T>>> => Promise.all([...list]).then(toList),
 };
 
 export const tuple2 = tuple[2];

--- a/packages/easy/test/utils/Promise.test.ts
+++ b/packages/easy/test/utils/Promise.test.ts
@@ -1,4 +1,4 @@
-import { reject, resolve, toList, toResults, tuple, tuple2, tuple3, tuple4, tuple5, when } from '../../src';
+import { List, reject, resolve, toList, toResults, tuple, tuple2, tuple3, tuple4, tuple5, when } from '../../src';
 import { Dev } from '../ref';
 import '@thisisagile/easy-test';
 
@@ -108,6 +108,13 @@ describe('tuple', () => {
       .then(([, ms]) => toList(ms));
 
     expect(res).toHaveLength(2);
+    expect(res[1]).toBeInstanceOf(Manager);
+  });
+
+  test('resolve sync and async list', async () => {
+    const res = await tuple.list([asyncM(ceo), asyncM(cto)]);
+    expect(res).toHaveLength(2);
+    expect(res).toBeInstanceOf(List);
     expect(res[1]).toBeInstanceOf(Manager);
   });
 });


### PR DESCRIPTION
…se.ts

Added `List` import in Promise.test.ts and Promise.ts. Introduced a new `list` method in Promise.ts that converts an array of Promises into a List. This functionality is tested in Promise.test.ts.