### PR TITLE
fix(easy): Refactor toWords regex to not use lookbehind since is not …

### DIFF
--- a/packages/easy/src/types/Text.ts
+++ b/packages/easy/src/types/Text.ts
@@ -16,8 +16,10 @@ export const asString = (t?: unknown, alt: Get<Text> = ''): string => (isText(t)
 export const replaceAll = (origin: Text, search: Text, replace: Text = ''): string => asString(origin).split(asString(search)).join(asString(replace));
 
 export const toWords = (input: unknown): string[] => {
-  const regex = /(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|[_\W]+/g;
-  return asString(input).split(regex).filter(Boolean);
+  return asString(input)
+    .replace(/(\p{Lower})(\p{Upper})/gu, '$1 $2')
+    .replace(/(\p{Upper})(\p{Upper}\p{Lower})/gu, '$1 $2')
+    .split(/[_\W]+/g).filter(Boolean);
 };
 
 export const kebab = (s = ''): string => toWords(s).join('-').toLowerCase();


### PR DESCRIPTION
…supported on safari 15