### PR TITLE
feat(easy): Make Jwt class universal.

### DIFF
--- a/packages/easy/package.json
+++ b/packages/easy/package.json
@@ -35,15 +35,16 @@
   "devDependencies": {
     "@thisisagile/easy-test": "workspace:*",
     "@types/form-urlencoded": "^4.4.0",
-    "@types/jsonwebtoken": "^9.0.6",
+    "@types/jsonwebtoken": "^9",
     "@types/luxon": "3.4.2",
-    "@types/validator": "^13.11.9"
+    "@types/validator": "^13.11.9",
+    "jsonwebtoken": "^9.0.2"
   },
   "dependencies": {
     "@types/uuid": "^9.0.8",
     "axios": "^1.3.4",
     "form-urlencoded": "^6.1.0",
-    "jsonwebtoken": "^9.0.0",
+    "jwt-decode": "^4.0.0",
     "luxon": "^3.4.4",
     "reflect-metadata": "^0.1.13",
     "uuid": "^9.0.1",

--- a/packages/easy/src/security/Jwt.ts
+++ b/packages/easy/src/security/Jwt.ts
@@ -1,33 +1,7 @@
-import { Algorithm, decode, sign, verify } from 'jsonwebtoken';
-import { ctx, Json, OneOrMore, Optional, tryTo, Validatable, Value } from '../types';
+import { Json, Value } from '../types';
+import { jwtDecode as decode } from 'jwt-decode';
 
-interface SignOptions {
-  audience?: Optional<OneOrMore<string>>;
-  issuer?: Optional<string>;
-}
-export class Jwt extends Value implements Validatable {
-  get isValid(): boolean {
-    return (
-      tryTo(() => ctx.env.get('tokenPublicKey') ?? '')
-        .map(key => verify(this.value, key))
-        .map(() => true)
-        .orElse() ?? false
-    );
-  }
-
-  static sign = (token: Json, options?: SignOptions): Jwt =>
-    tryTo(() => ctx.env.get('tokenPrivateKey') ?? '')
-      .is.not.empty()
-      .map(key =>
-        sign(token, key, {
-          ...options,
-          expiresIn: ctx.env.get('tokenExpiresIn') ?? '1h',
-          keyid: ctx.env.get('tokenKeyid') ?? 'easy',
-          algorithm: ctx.env.get('tokenAlgorithm', 'RS256') as Algorithm,
-        })
-      )
-      .map(s => new Jwt(s)).value;
-
+export class Jwt extends Value {
   static of = (a: { jwt: string }): Jwt => new Jwt(a.jwt);
 
   decode = (): Json => decode(this.value) as Json;

--- a/packages/easy/test/security/Jwt.test.ts
+++ b/packages/easy/test/security/Jwt.test.ts
@@ -1,11 +1,12 @@
 import '@thisisagile/easy-test';
-import { Jwt, validate } from '../../src';
+import sign from 'jsonwebtoken';
+
+import { ctx, Jwt } from '../../src';
 import { Dev } from '../ref';
 
 describe('Test Jwt', () => {
   const dev = Dev.Naoufal.toJSON();
-  const jwt = Jwt.sign(dev);
-  const falseJwt = Jwt.of({ jwt: 'wrong' });
+  const jwt = Jwt.of({ jwt: sign.sign(dev, ctx.env.get('tokenPrivateKey') as string) });
 
   test('Check if a valid jwt contains the token.', () => {
     expect(jwt).toBeValid();
@@ -17,18 +18,7 @@ describe('Test Jwt', () => {
     expect(res2).toMatchObject(dev);
   });
 
-  test('Validate', () => {
-    expect(validate(jwt)).toBeValid();
-    expect(validate(falseJwt)).not.toBeValid();
-  });
-
   test('toJSON.', () => {
     expect(jwt.toJSON()).toStrictEqual({ jwt: jwt.value });
-  });
-
-  test('Sign with options', () => {
-    const jwt = Jwt.sign(dev, { audience: 'audience', issuer: 'issuer' });
-    expect(jwt.decode().iss).toBe('issuer');
-    expect(jwt.decode().aud).toBe('audience');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,13 +1791,14 @@ __metadata:
   dependencies:
     "@thisisagile/easy-test": "workspace:*"
     "@types/form-urlencoded": "npm:^4.4.0"
-    "@types/jsonwebtoken": "npm:^9.0.6"
+    "@types/jsonwebtoken": "npm:^9"
     "@types/luxon": "npm:3.4.2"
     "@types/uuid": "npm:^9.0.8"
     "@types/validator": "npm:^13.11.9"
     axios: "npm:^1.3.4"
     form-urlencoded: "npm:^6.1.0"
-    jsonwebtoken: "npm:^9.0.0"
+    jsonwebtoken: "npm:^9.0.2"
+    jwt-decode: "npm:^4.0.0"
     luxon: "npm:^3.4.4"
     reflect-metadata: "npm:^0.1.13"
     uuid: "npm:^9.0.1"
@@ -2025,7 +2026,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsonwebtoken@npm:*, @types/jsonwebtoken@npm:^9.0.6":
+"@types/jsonwebtoken@npm:*, @types/jsonwebtoken@npm:^9, @types/jsonwebtoken@npm:^9.0.6":
   version: 9.0.6
   resolution: "@types/jsonwebtoken@npm:9.0.6"
   dependencies:
@@ -7426,7 +7427,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonwebtoken@npm:^9.0.0":
+"jsonwebtoken@npm:^9.0.0, jsonwebtoken@npm:^9.0.2":
   version: 9.0.2
   resolution: "jsonwebtoken@npm:9.0.2"
   dependencies:
@@ -7483,6 +7484,13 @@ __metadata:
     jwa: "npm:^2.0.0"
     safe-buffer: "npm:^5.0.1"
   checksum: 10c0/f1ca77ea5451e8dc5ee219cb7053b8a4f1254a79cb22417a2e1043c1eb8a569ae118c68f24d72a589e8a3dd1824697f47d6bd4fb4bebb93a3bdf53545e721661
+  languageName: node
+  linkType: hard
+
+"jwt-decode@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jwt-decode@npm:4.0.0"
+  checksum: 10c0/de75bbf89220746c388cf6a7b71e56080437b77d2edb29bae1c2155048b02c6b8c59a3e5e8d6ccdfd54f0b8bda25226e491a4f1b55ac5f8da04cfbadec4e546c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In order for easy to work on react-native we need to replace jsonwebtoken and loose the signing capabilities which is dependant on node crypto for a universal alternative in order to decode in all environments.